### PR TITLE
15 pending store updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0
+
+- BREAKING: Rename `fromCache` and `cacheKey` to `__fromCache` and `__cacheKey` to prevent collisions with fetched data
+- Add support for pending actions #15
+- Prefix cache entries with `withData__`
+
 ## 0.7.0
 
 - Add `optimisticUpdate()` to rerender with data

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ withData({
 })
 ```
 
-**NOTE:** Any action that you would like to do custom caching with but return a `cacheKey` and `fromCache` property to avoid the default behavior from overriding the custom action cache. You should implement the store.js [expire plugin](https://github.com/marcuswestin/store.js/blob/master/plugins/expire.js) to prevent key recycling if your action uses store.js internally. See [axios-store-plugin](https://github.com/usePF/axios-store-plugin) for an example implementation.
+**NOTE:** Any action that you would like to handle the caching for should return `__cacheKey` and `__fromCache` properties in the result to avoid the default cache from overriding any custom caching.
+
+Consider implementing the store.js [expire plugin](https://github.com/marcuswestin/store.js/blob/master/plugins/expire.js) to prevent key recycling if your action uses store.js internally. See [axios-store-plugin](https://github.com/usePF/axios-store-plugin) for an example implementation of custom caching.
 
 #### Polling
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -36,8 +36,10 @@ var set = exports.set = function set(key, value) {
   _store2.default.set(key, value, expiresAt);
 };
 
-var observeData = function observeData(defaultKey, dataFn, onNext, onError) {
+var observeData = function observeData(actionName, dataFn, onNext, onError) {
   var options = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
+
+  var defaultKey = "withData__" + actionName;
 
   var _defaultConfig$option = _extends({}, defaultConfig, options),
       maxAge = _defaultConfig$option.maxAge,
@@ -54,12 +56,12 @@ var observeData = function observeData(defaultKey, dataFn, onNext, onError) {
     return dataFn().then(function () {
       var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-      var cacheKey = _ref.cacheKey,
-          fromCache = _ref.fromCache,
-          data = _objectWithoutProperties(_ref, ["cacheKey", "fromCache"]);
+      var __cacheKey = _ref.__cacheKey,
+          __fromCache = _ref.__fromCache,
+          data = _objectWithoutProperties(_ref, ["__cacheKey", "__fromCache"]);
 
-      var key = cacheKey || defaultKey;
-      if (!fromCache) set(key, data, maxAge);
+      var key = __cacheKey || defaultKey;
+      if (!__fromCache) set(key, data, maxAge);
       return key;
     }).catch(onError);
   };

--- a/lib/withData.js
+++ b/lib/withData.js
@@ -172,7 +172,7 @@ function withData(actions) {
         if (isAxiosError) {
           _this3.setState(function (prevState) {
             return (0, _immutabilityHelper2.default)(prevState, {
-              data: _defineProperty({}, actionName, { $merge: { error: error, loading: false } })
+              data: _defineProperty({}, actionName, { $merge: { loading: false, error: error } })
             });
           });
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "withdata",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "HOC for managing data via props. Inspired by apollo-client.",
   "main": "index.js",
   "scripts": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -14,12 +14,13 @@ export const set = (key, value, maxAge = defaultConfig.maxAge) => {
 };
 
 export const observeData = (
-  defaultKey,
+  actionName,
   dataFn,
   onNext,
   onError,
   options = {}
 ) => {
+  const defaultKey = `withData__${actionName}`;
   const { maxAge, noCache, pollInterval } = { ...defaultConfig, ...options };
   const cachedData = store.get(defaultKey);
   const shouldUseCache = !noCache && cachedData;
@@ -29,9 +30,9 @@ export const observeData = (
   };
   const fetchFreshData = () =>
     dataFn()
-      .then(({ cacheKey, fromCache, ...data } = {}) => {
-        const key = cacheKey || defaultKey;
-        if (!fromCache) set(key, data, maxAge);
+      .then(({ __cacheKey, __fromCache, ...data } = {}) => {
+        const key = __cacheKey || defaultKey;
+        if (!__fromCache) set(key, data, maxAge);
         return key;
       })
       .catch(onError);

--- a/src/withData.jsx
+++ b/src/withData.jsx
@@ -107,7 +107,7 @@ function withData(actions) {
           this.setState(prevState =>
             update(prevState, {
               data: {
-                [actionName]: { $merge: { error, loading: false } }
+                [actionName]: { $merge: { loading: false, error } }
               }
             })
           );


### PR DESCRIPTION
- BREAKING: Rename `fromCache` and `cacheKey` to `__fromCache` and `__cacheKey` to prevent collisions with fetched data
- Add support for pending actions #15
- Prefix cache entries with `withData__`

Closes #15 