### PR TITLE
wrap arrays in an object with key of results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0
+
+- Convert array responses into objects with results arrays
+
 ## 0.12.0
 
 - Add Data component

--- a/README.md
+++ b/README.md
@@ -287,3 +287,19 @@ const App = () => (
 - `store: Object` - _**Required**_
   - `observeData: Function` - _**Required**_ Returns data from the cache or fetches it - see code for signature - must return an id for unsubscribing
   - `unobserveData: Function` - _**Required**_ Accepts an id and stops observing it
+
+## axiosStore
+
+axiosStore is a light wrapper around axios that allows for caching get requests using `cache.js`.
+
+**NOTE:** As of v0.13.0 all array responses will instead return an object with a results array.
+
+Example:
+
+```js
+APIResponse = [ 0, 2, 4, 6, 8 ];
+
+// gets turned into
+
+formattedResponse = { results: [ 0, 2, 4, 6, 8 ] };
+```

--- a/lib/axiosStore.js
+++ b/lib/axiosStore.js
@@ -45,7 +45,9 @@ var axiosStore = function axiosStore(axiosInstance) {
       return axiosInstance.get.apply(axiosInstance, arg);
     }).then(function (_ref) {
       var data = _ref.data;
-      return _extends({}, data, { __cacheKey: cacheKey });
+
+      var wrappedData = Array.isArray(data) ? { results: data } : data;
+      return _extends({}, wrappedData, { __cacheKey: cacheKey });
     }).catch(function (error) {
       if (_store2.default.get(cacheKey) === PLACEHOLDER) {
         _store2.default.remove(cacheKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-data",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-data",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Utilities for managing data. Inspired by react-apollo.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/axiosStore.js
+++ b/src/axiosStore.js
@@ -22,7 +22,10 @@ const axiosStore = axiosInstance => {
         })
       : createPlaceholder(cacheKey)
           .then(() => axiosInstance.get(...arg))
-          .then(({ data }) => ({ ...data, __cacheKey: cacheKey }))
+          .then(({ data }) => {
+            const wrappedData = Array.isArray(data) ? { results: data } : data;
+            return { ...wrappedData, __cacheKey: cacheKey };
+          })
           .catch(error => {
             if (store.get(cacheKey) === PLACEHOLDER) {
               store.remove(cacheKey);


### PR DESCRIPTION
This PR changes the format of an API response that returns an array, to instead return an object with a results array.

Example:

```js
APIResponse = [ 0, 2, 4, 6, 8 ];

// gets turned into

formattedResponse = { results: [ 0, 2, 4, 6, 8 ] };
```