### PR TITLE
allow null maxAge for cached items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## 0.14.0
+
+- Allow `null` maxAge to never expire a key
+
 ## 0.13.2
 
-- Convert number responses to objects with value property
+- Convert Number responses to objects with value property
 
 ## 0.13.1
 
-- Convert string responses to objects with value property
+- Convert String responses to objects with value property
 
 ## 0.13.0
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -29,11 +29,11 @@ _store2.default.addPlugin([_expire2.default, _observe2.default]);
 
 var defaultConfig = { maxAge: 1 };
 
-var set = exports.set = function set(cacheKey, value) {
-  var maxAge = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : defaultConfig.maxAge;
-
-  var expiresAt = new Date().getTime() + maxAge * SECOND;
-  return Promise.resolve(_store2.default.set(cacheKey, value, expiresAt));
+var set = exports.set = function set(cacheKey, value, maxAge) {
+  // Allow null to bypass default cache value and act as "never expire"
+  var userMaxAgeOrDefault = maxAge || defaultConfig.maxAge;
+  var expiresAt = new Date().getTime() + userMaxAgeOrDefault * SECOND;
+  return maxAge === null ? Promise.resolve(_store2.default.set(cacheKey, value)) : Promise.resolve(_store2.default.set(cacheKey, value, expiresAt));
 };
 
 var getSync = exports.getSync = function getSync(cacheKey, defaultValue) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-data",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-data",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Utilities for managing data. Inspired by react-apollo.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -8,9 +8,13 @@ store.addPlugin([expirePlugin, observePlugin]);
 
 const defaultConfig = { maxAge: 1 };
 
-export const set = (cacheKey, value, maxAge = defaultConfig.maxAge) => {
-  const expiresAt = new Date().getTime() + maxAge * SECOND;
-  return Promise.resolve(store.set(cacheKey, value, expiresAt));
+export const set = (cacheKey, value, maxAge) => {
+  // Allow null to bypass default cache value and act as "never expire"
+  const userMaxAgeOrDefault = maxAge || defaultConfig.maxAge;
+  const expiresAt = new Date().getTime() + userMaxAgeOrDefault * SECOND;
+  return maxAge === null
+    ? Promise.resolve(store.set(cacheKey, value))
+    : Promise.resolve(store.set(cacheKey, value, expiresAt));
 };
 
 export const getSync = (cacheKey, defaultValue) => {


### PR DESCRIPTION
when maxAge === null, the key will never expire, ignoring defaults.

```js
cache.set('hello', 'world') // expires in 1 second (default applied)
cache.set('hello', 'world', 60) // expires in 1 minute (explicitly applied)
cache.set('hello', 'world', null) // never expires (default ignored)
```